### PR TITLE
make runnable on Chrome

### DIFF
--- a/bleu.html
+++ b/bleu.html
@@ -77,7 +77,7 @@
 <div align="center" id="segDetailContainer"></div>
 <br/>
 </body>
-<script type="application/javascript;version=1.8">
+<script type="text/javascript">
 var tstSets = [];
 var refSets = [];
 var srcSets = [];

--- a/js/utils.js
+++ b/js/utils.js
@@ -45,7 +45,11 @@ jQuery.fn.compare = function(other) {
 };
 
 // Utility function to get all keys for a hash
-keys = function(o) { return [ p for (p in o) ]; };
+keys = function(o) {
+    var ret=[],p;
+    for(p in o) if(Object.prototype.hasOwnProperty.call(o,p)) ret.push(p);
+    return ret;
+};
 
 // Utility function to check whether two hashes are equal
 function hashequal(me, other) {


### PR DESCRIPTION
Only two small changes were required to run on Chrome:
1. The keys function was using special syntax in the for loop.
2. The script type needed to be `text/javascript` instead of
   `application/javascript;version=1.8`.

It still works on FireFox too, of course.
