### PR TITLE
Fix incompatibility with latest Chrome.

### DIFF
--- a/bleu.html
+++ b/bleu.html
@@ -1010,7 +1010,7 @@ $(document).ready(function() {
 
             // build the doc plot strip of plots if there is more
             // than one document otherwise we don't need to
-            var numDocuments = keys(scontainer.documentScores).length;
+            var numDocuments = Object.keys(scontainer.documentScores).length;
             if ( numDocuments > 0) {
 
                 // Set the height and width for the container

--- a/js/utils.js
+++ b/js/utils.js
@@ -48,16 +48,10 @@ jQuery.fn.compare = function(other) {
     return true;
 };
 
-// Utility function to get all keys for a hash
-keys = function(o) {
-    var ret=[],p;
-    for(p in o) if(Object.prototype.hasOwnProperty.call(o,p)) ret.push(p);
-    return ret;
-};
 
 // Utility function to check whether two hashes are equal
 function hashequal(me, other) {
-    if (!$(keys(me)).compare(keys(other))) { return false; }
+    if (!$(Object.keys(me)).compare(Object.keys(other))) { return false; }
     for (var key in me) {
         if (me[key] != other[key]) {
             return false;


### PR DESCRIPTION
- Use `Object.keys()` instead of using our own hacky `keys()` implementation.
